### PR TITLE
Added alpha variants and overlay colors

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -17,7 +17,7 @@ export interface PresetRadixOptions {
    * Customize the selector used to apply the dark versions of the color palette
    * @default ".dark-theme"
    */
-  darkSelector?: string;
+  darkSelector?: string | boolean;
 
   /**
    * Customize the selector used to apply the light versions of the color palette


### PR DESCRIPTION
As discussed here https://github.com/endigma/unocss-preset-radix/issues/4 this is the PR for add alpha variants and overlay colors (whiteA and blackA).

For add the alpha variants and overlay colors you need to explicitly add them in config, in this way someone can exclude them if they are not using.

Example config:

```js
// Add 'blueA' for blue alpha and 'whiteA' for overlay white
presetRadix({
  palette: ['blue', 'blueA', 'green', 'amberA', 'whiteA'],
}),
``` 

Overlay colors: `whiteA` and `blackA`
Alpha variants: `blueA`, `greenA`, etc...

The dark variants is added automatically, so for example when you add 'blueA' also the 'blueDarkA' will be added.

I have also exclude dark colors if you set the option `darkSelector` to falsy value so that if someone are not using dark mode, the CSS for dark colors will not be generated.

I see there is not any tests and not sure how is your workflow for tests code, I did a build and move dist folder to a unocss project for testing. I think would be good to have some tests.

Let me know if you have any feedback about and I will adjust accordingly.

Thanks