### PR TITLE
Add alpha variants and overlay colors 

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ export default defineConfig({
 
 ### palette
 
-An array of the Radix UI Colors you'd like to include. Dark mode is automatic.
+An array of the Radix UI Colors you'd like to include. Dark mode and alpha variants are automatic. Overlay colors are added by default.
 
 ### prefix
 

--- a/README.md
+++ b/README.md
@@ -46,7 +46,7 @@ The selector used for dark mode palette. Default is `:root, .light-theme`.
 
 ### aliases
 
-A key value object of color aliases in the format `alias: target` that allows you to set aliases for the color palette. You cannot set aliases to other aliases.
+A key value object of color aliases in the format `alias: target` that allows you to set aliases for the color palette. You cannot set aliases to other aliases. Alpha variants for aliases are generated automatically, so for then given alias `brand: blue`, an alias `brandA: blueA` will also be generated.
 
 ### extend
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -74,36 +74,23 @@ export function presetRadix(options: PresetRadixOptions): Preset {
         ([, color]) => {
           let target: string = "";
 
-          const isAlphaVariant = color[color.length - 1] === "A"
-          const colorWithoutAlpha = isAlphaVariant ? color.substring(0, color.length - 1) : color;
-
-          if (selectedColors.includes(colorWithoutAlpha as RadixColors)) {
+          if (selectedColors.includes(color as RadixColors)) {
             target = color;
-          } else if (colorWithoutAlpha in selectedAliases) {
-            target = selectedAliases[colorWithoutAlpha];
-
-            if (isAlphaVariant) {
-              target += "A";
-            }
+          } else if (color in selectedAliases) {
+            target = selectedAliases[color];
           }
 
           if (target) {
-            return minify(`
-              .hue-${color} {
-                ${prefix}hue1: var(${prefix}${target}1);
-                ${prefix}hue2: var(${prefix}${target}2);
-                ${prefix}hue3: var(${prefix}${target}3);
-                ${prefix}hue4: var(${prefix}${target}4);
-                ${prefix}hue5: var(${prefix}${target}5);
-                ${prefix}hue6: var(${prefix}${target}6);
-                ${prefix}hue7: var(${prefix}${target}7);
-                ${prefix}hue8: var(${prefix}${target}8);
-                ${prefix}hue9: var(${prefix}${target}9);
-                ${prefix}hue10: var(${prefix}${target}10);
-                ${prefix}hue11: var(${prefix}${target}11);
-                ${prefix}hue12: var(${prefix}${target}12);
-              }
-            `);
+            let css = `.hue-${color} {`;
+
+            for (let shade = 1; shade <= 12; shade++) {
+              css += `${prefix}hue${shade}: var(${prefix}${target}${shade});`
+              css += `${prefix}hueA${shade}: var(${prefix}${target}A${shade});`
+            }
+
+            css += "}";
+
+            return minify(css);
           }
 
           return "";

--- a/src/index.ts
+++ b/src/index.ts
@@ -39,6 +39,7 @@ export interface PresetRadixOptions {
 export function generateAliases(colors: ReturnType<typeof generateColors>, aliases: ColorAliases) {
   return Object.entries(aliases).reduce((o, [alias, target]) => {
     o[alias] = colors[target];
+    o[`${alias}A`] = colors[`${target}A`];
     return o;
   }, {} as { [key: string]: { [key: number]: string } });
 }

--- a/src/index.ts
+++ b/src/index.ts
@@ -63,7 +63,6 @@ export function presetRadix(options: PresetRadixOptions): Preset {
   const hues = generateHues(prefix);
   const aliases = generateAliases(colors, selectedAliases);
 
-  console.log(colors)
   return {
     name: "unocss-preset-radix",
     layers: {

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,7 +4,7 @@ import type { Preset } from "@unocss/core";
 
 export * from "./radix";
 
-export type ColorAliases = { [key: string]: RadixColors };
+export type ColorAliases = Record<string, RadixColors>;
 
 export interface PresetRadixOptions {
   palette: readonly RadixColors[];
@@ -41,7 +41,7 @@ export function generateAliases(colors: ReturnType<typeof generateColors>, alias
     o[alias] = colors[target];
     o[`${alias}A`] = colors[`${target}A`];
     return o;
-  }, {} as { [key: string]: { [key: number]: string } });
+  }, {} as Record<string, Record<number, string>>);
 }
 
 function minify(css: string) {
@@ -63,6 +63,7 @@ export function presetRadix(options: PresetRadixOptions): Preset {
   const hues = generateHues(prefix);
   const aliases = generateAliases(colors, selectedAliases);
 
+  console.log(colors)
   return {
     name: "unocss-preset-radix",
     layers: {
@@ -102,7 +103,7 @@ export function presetRadix(options: PresetRadixOptions): Preset {
         },
       ],
     ],
-    extendTheme(theme: { [key: string]: any }) {
+    extendTheme(theme: Record<string, any>) {
       theme.colors = {
         ...colors,
         ...aliases,

--- a/src/index.ts
+++ b/src/index.ts
@@ -73,10 +73,18 @@ export function presetRadix(options: PresetRadixOptions): Preset {
         /^hue-(.+)$/,
         ([, color]) => {
           let target: string = "";
-          if (selectedColors.includes(color as RadixColors)) {
+
+          const isAlphaVariant = color[color.length - 1] === "A"
+          const colorWithoutAlpha = isAlphaVariant ? color.substring(0, color.length - 1) : color;
+
+          if (selectedColors.includes(colorWithoutAlpha as RadixColors)) {
             target = color;
-          } else if (color in selectedAliases) {
-            target = selectedAliases[color];
+          } else if (colorWithoutAlpha in selectedAliases) {
+            target = selectedAliases[colorWithoutAlpha];
+
+            if (isAlphaVariant) {
+              target += "A";
+            }
           }
 
           if (target) {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,7 +59,12 @@ export function generateColors(palette: Palette, prefix: string) {
 }
 
 export function generateHues(prefix: string) {
-  const hue = Array.from({ length: 12 }, (_, i) => `var(${prefix}hue${i})`);
+  const hue: Record<number, string> = {};
+
+  for (let shade = 1; shade <= 12; shade++) {
+    hue[shade] = `var(${prefix}hue${shade})`;
+  }
+
   return { hue };
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -59,13 +59,17 @@ export function generateColors(palette: Palette, prefix: string) {
 }
 
 export function generateHues(prefix: string) {
-  const hue: Record<number, string> = {};
+  function createHue(postfix: string = ""): Record<number, string> {
+    const hue: Record<number, string> = {};
 
-  for (let shade = 1; shade <= 12; shade++) {
-    hue[shade] = `var(${prefix}hue${shade})`;
+    for (let shade = 1; shade <= 12; shade++) {
+      hue[shade] = `var(${prefix}hue${postfix}${shade})`;
+    }
+
+    return hue;
   }
 
-  return { hue };
+  return { hue: createHue(), hueA: createHue("A") };
 }
 
 export function newPalette(...names: RadixColors[]): Palette {

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -79,14 +79,6 @@ export function genCSS(
     css.push(`${prefix}${label}${isAlpha ? "A" : ""}${shade}:${value};`);
   }
 
-  const blackAScale = getScale("blackA")
-  const whiteAScale = getScale("whiteA")
-
-  function pushOverlays() {
-    Object.entries(blackAScale).forEach(entry => pushVar("black", entry, true));
-    Object.entries(whiteAScale).forEach(entry => pushVar("white", entry, true));
-  }
-
   css.push(`${lightSelector} {`);
   for (const [label, color] of palette) {
     Object.entries(color.light).forEach(entry => pushVar(label, entry));
@@ -102,7 +94,8 @@ export function genCSS(
   css.push("}");
 
   css.push(":root {");
-  pushOverlays();
+  Object.entries(getScale("blackA")).forEach(entry => pushVar("black", entry, true));
+  Object.entries(getScale("whiteA")).forEach(entry => pushVar("white", entry, true));
   css.push("}");
 
 


### PR DESCRIPTION
As mentioned in #8, this PR makes it so alpha variants of the chosen palette are generated automatically for you, and also adds the overlay colors `blackA` and `whiteA`. Alpha variants are also added for aliases, so for a given alias `brand: blue`, the alias `brandA: blueA` will also be generated.