### PR TITLE
Fix type error when passing options to presetRadix

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -65,7 +65,7 @@ function dataVariant(
   }));
 }
 
-export const presetRadix = definePreset((options: PresetRadixOptions) => {
+export const presetRadix = definePreset((options?: PresetRadixOptions) => {
   const {
     prefix = "--un-preset-radix-",
     darkSelector = ".dark-theme",


### PR DESCRIPTION
updated presetRadix constant to correctly export a PresetFactory and correct a typescript error that is thrown when presetRadix is passed options in unocss.config.ts